### PR TITLE
removing redefinition of Exception

### DIFF
--- a/lib/activerecord-tableless.rb
+++ b/lib/activerecord-tableless.rb
@@ -29,10 +29,8 @@ module ActiveRecord
   #
   module Tableless
 
-    class Exception < StandardError
-    end
-    class NoDatabase < Exception
-    end
+    class NoDatabase < StandardError; end
+    class Unsupported < StandardError; end
 
     def self.included( base ) #:nodoc:
       base.send :extend, ActsMethods
@@ -59,7 +57,7 @@ module ActiveRecord
             :columns => []
           }
         else
-          raise Exception.new("Sorry, ActiveRecord version #{ActiveRecord::VERSION::STRING} is not supported")
+          raise Unsupported.new("Sorry, ActiveRecord version #{ActiveRecord::VERSION::STRING} is not supported")
         end
 
         # extend
@@ -157,7 +155,7 @@ module ActiveRecord
 
         end
       else
-        raise Exception.new("Unsupported ActiveRecord version")
+        raise Unsupported.new("Unsupported ActiveRecord version")
       end
 
       def transaction(&block)


### PR DESCRIPTION
This impacts code within the ActiveRecord namespace, as the exception object now becomes `ActiveRecord::Exception` and not `::Exception`  Any lines such as `rescue Exception` within an ActiveRecord model will no longer catch `::Exception` errors.

closes softace/activerecord-tableless#10
