### PR TITLE
Add _create_record and _update_record methods to fake InstanceMethods

### DIFF
--- a/lib/activerecord-tableless.rb
+++ b/lib/activerecord-tableless.rb
@@ -228,7 +228,7 @@ module ActiveRecord
         ""
       end
 
-      %w(create create_record update update_record).each do |method_name|
+      %w(create create_record _create_record update update_record _update_record).each do |method_name|
         define_method(method_name) do |*args|
           case self.class.tableless_options[:database]
           when :pretend_success


### PR DESCRIPTION
Needed to support Rails master and 4-1-stable. These methods are renamed there (see https://github.com/rails/rails/commit/df1df87e86a43d9e5631dd182e2e4a4d557d74c8)
