### PR TITLE
Add quote_column_name to connection object.

### DIFF
--- a/lib/activerecord-tableless.rb
+++ b/lib/activerecord-tableless.rb
@@ -203,6 +203,9 @@ module ActiveRecord
         def conn.quote_table_name(*args)
           ""
         end
+        def conn.quote_column_name(*args)
+          ""
+        end
         def conn.substitute_at(*args)
           nil
         end


### PR DESCRIPTION
This was causing a NoMethodError on a Rails 3 application.
