### PR TITLE
Fixes issue #17 - NoMethodError: undefined method `sanitize_limit' for #<Object:...>

### DIFF
--- a/lib/activerecord-tableless.rb
+++ b/lib/activerecord-tableless.rb
@@ -213,6 +213,26 @@ module ActiveRecord
           end
           schema_cache
         end
+        # Fixes Issue #17. https://github.com/softace/activerecord-tableless/issues/17
+        # The following method is from the ActiveRecord gem: /lib/active_record/connection_adapters/abstract/database_statements.rb .
+        # Sanitizes the given LIMIT parameter in order to prevent SQL injection.
+        #
+        # The +limit+ may be anything that can evaluate to a string via #to_s. It
+        # should look like an integer, or a comma-delimited list of integers, or
+        # an Arel SQL literal.
+        #
+        # Returns Integer and Arel::Nodes::SqlLiteral limits as is.
+        # Returns the sanitized limit parameter, either as an integer, or as a
+        # string which contains a comma-delimited list of integers.
+        def conn.sanitize_limit(limit)
+          if limit.is_a?(Integer) || limit.is_a?(Arel::Nodes::SqlLiteral)
+            limit
+          elsif limit.to_s.include?(',')
+            Arel.sql limit.to_s.split(',').map{ |i| Integer(i) }.join(',')
+          else
+            Integer(limit)
+          end
+        end
         conn
       end
 


### PR DESCRIPTION
When trying to access a table-less model through an association, it was throwing a 'NoMethodError: undefined method `sanitize_limit' for #Object:...".

Fixed the error by defining that method on the "connection" variable. Took the method from the ActiveRecord gem: /lib/active_record/connection_adapters/abstract/database_statements.rb .
