### PR TITLE
Patch the "column" method for ActiveRecord 4.2

### DIFF
--- a/lib/activerecord-tableless.rb
+++ b/lib/activerecord-tableless.rb
@@ -86,7 +86,12 @@ module ActiveRecord
 
       # Register a new column.
       def column(name, sql_type = nil, default = nil, null = true)
-        tableless_options[:columns] << ActiveRecord::ConnectionAdapters::Column.new(name.to_s, default, sql_type.to_s, null)
+        if ActiveRecord::VERSION::STRING >= "4.2.0"
+          cast_type = "ActiveRecord::Type::#{sql_type.to_s.camelize}".constantize.new
+          tableless_options[:columns] << ActiveRecord::ConnectionAdapters::Column.new(name.to_s, default, cast_type, sql_type.to_s, null)
+        else
+          tableless_options[:columns] << ActiveRecord::ConnectionAdapters::Column.new(name.to_s, default, sql_type.to_s, null)
+        end
       end
 
       # Register a set of colums with the same SQL type


### PR DESCRIPTION
Fixes softace/activerecord-tableless#22

Putting together:
- @david135 's PR: [#23](https://github.com/david135/activerecord-tableless/commit/800393c52bd254f812e89d75f028a5d0730e79d9)
- @seliestel 's comment: https://github.com/softace/activerecord-tableless/issues/22#issuecomment-94244111
