### PR TITLE
gems must require their own dependencies

### DIFF
--- a/lib/activerecord-tableless.rb
+++ b/lib/activerecord-tableless.rb
@@ -28,6 +28,7 @@ module ActiveRecord
   #  end
   #
   module Tableless
+    require 'active_record'
 
     class NoDatabase < StandardError; end
     class Unsupported < StandardError; end


### PR DESCRIPTION
According to the bundler team, relying on bundler to require dependencies is wrong. add_runtime_dependency for activerecord is not properly being required unless the Gemfile is in a specific order. 

(https://github.com/bundler/bundler/issues/1041#issuecomment-7542750)
